### PR TITLE
Fill in some V1 details

### DIFF
--- a/src/v2-mapping.ts
+++ b/src/v2-mapping.ts
@@ -465,7 +465,7 @@ export function handleProcessProposal(event: ProcessProposal): void {
     .concat("-token-")
     .concat(proposal.paymentToken.toHex());
 
-  let isNewMember = member != null && member.exists == true ? false : true;
+  let isNewMember = member != null && !member.exists;
 
   //NOTE: PROPOSAL PASSED
   if (event.params.didPass) {


### PR DESCRIPTION
Added some fields that can make the webapp logic easier for V1:

- Added `yesShares` and `noShares`
- Added `moloch` entity fields such as period lengths, dilution bound, processing reward, etc.